### PR TITLE
Add missing checks to didSaveRecord to avoid errors regarding undefin…

### DIFF
--- a/addon/patches/store.js
+++ b/addon/patches/store.js
@@ -43,6 +43,16 @@ Store.reopen({
   },
 
   didSaveRecord(internalModel, { data }) {
+    if (data === undefined) {
+      data = {
+        meta: undefined,
+        _top_level_meta: undefined
+      }
+    } else if (!('meta' in data)) {
+      data.meta = undefined;
+      data._top_level_meta = undefined;
+    }
+    
     internalModel.recordReference.__update_meta(data.meta);
     internalModel.recordReference.__update_responseMeta(data._top_level_meta);
     return this._super(...arguments);


### PR DESCRIPTION
Resolves #2 by checking if `data` or `data.meta` is defined. If `data` is missing it will be created with undefined `meta` and `_top_level_meta`.